### PR TITLE
Adopt levionessa/elixir_style_guide as the Elixir style guide

### DIFF
--- a/elixir/style.md
+++ b/elixir/style.md
@@ -1,0 +1,3 @@
+# Elixir Style Guide
+
+See [levionessa/elixir_style_guide](https://github.com/levionessa/elixir_style_guide)


### PR DESCRIPTION
This PR adopts [levionessa/elixir_style_guide](https://github.com/levionessa/elixir_style_guide) as EVEolve's Elixir style guide.
